### PR TITLE
Renames ir-next to ir-boilerplate

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -222,7 +222,7 @@ async function install (context) {
       react-native run-android${androidInfo}
       ignite --help
 
-    ${gray('Read the walkthrough at https://github.com/infinitered/ignite-ir-next/blob/master/readme.md#boilerplate-walkthrough')}
+    ${gray('Read the walkthrough at https://github.com/infinitered/ignite-ir-boilerplate/blob/master/readme.md#boilerplate-walkthrough')}
 
     ${blue('Need additional help? Join our Slack community at http://community.infinite.red.')}
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "ignite-ir-boilerplate",
   "description": "Infinite Red's hot boilerplate for React Native.",
   "license": "MIT",
-  "repository": "infinitered/ignite-ir-next",
-  "homepage": "https://github.com/infinitered/ignite-ir-next",
+  "repository": "infinitered/ignite-ir-boilerplate",
+  "homepage": "https://github.com/infinitered/ignite-ir-boilerplate",
   "version": "2.0.0-rc.1",
   "files": [
     "boilerplate",
@@ -20,7 +20,7 @@
   "author": {
     "name": "Infinite Red",
     "email": "npm@infinite.red",
-    "url": "https://github.com/infinitered/ignite-ir-next"
+    "url": "https://github.com/infinitered/ignite-ir-boilerplate"
   },
   "scripts": {
     "lint": "standard",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Ignite IR Next
 
-[![Build Status](https://semaphoreci.com/api/v1/ir/ignite-ir-next/branches/master/badge.svg)](https://semaphoreci.com/ir/ignite-ir-next)
+[![Build Status](https://semaphoreci.com/api/v1/ir/ignite-ir-boilerplate/branches/master/badge.svg)](https://semaphoreci.com/ir/ignite-ir-boilerplate)
 
 ## The latest and greatest boilerplate for Infinite Red opinions
 


### PR DESCRIPTION
Moving over to `ignite-ir-boilerplate` in the repo.