### PR TITLE
Targetting different versions of React Native

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -1,9 +1,6 @@
 const options = require('./options')
 const { merge, pipe, assoc, omit, __ } = require('ramda')
-
-// The default version of React Native to install. We will want to upgrade
-// this when we test out new releases and they work well with our setup.
-const REACT_NATIVE_VERSION = '0.42.0'
+const { getReactNativeVersion } = require('./lib/react-native-version')
 
 /**
  * Is Android installed?
@@ -48,7 +45,10 @@ async function install (context) {
     .succeed()
 
   // attempt to install React Native or die trying
-  const rnInstall = await reactNative.install({ name, version: REACT_NATIVE_VERSION })
+  const rnInstall = await reactNative.install({
+    name,
+    version: getReactNativeVersion(context)
+  })
   if (rnInstall.exitCode > 0) process.exit(rnInstall.exitCode)
 
   // remove the __tests__ directory that come with React Native
@@ -232,4 +232,6 @@ async function install (context) {
   print.info(successMessage)
 }
 
-module.exports = { install }
+module.exports = {
+  install
+}

--- a/lib/react-native-version.js
+++ b/lib/react-native-version.js
@@ -1,0 +1,34 @@
+const { pathOr, is } = require('ramda')
+
+// the default React Native version for this boilerplate
+const REACT_NATIVE_VERSION = '0.42.0'
+
+/**
+ * Gets the React Native version to use.
+ *
+ * Attempts to read it from the command line, and if not there, falls back
+ * to the version we want for this boilerplate.  For example:
+ *
+ *   $ ignite new Custom --react-native-version 0.44.1
+ *
+ * @param {*} context - The gluegun context.
+ */
+const getReactNativeVersion = (context = {}) => {
+  // grab the user's choice (if any)
+  const value = pathOr(
+    REACT_NATIVE_VERSION,
+    ['parameters', 'options', 'react-native-version']
+  )(context)
+
+  // --react-native-version must be passed a string
+  if (!is(String, value)) {
+    return REACT_NATIVE_VERSION
+  }
+
+  return value
+}
+
+module.exports = {
+  REACT_NATIVE_VERSION,
+  getReactNativeVersion
+}

--- a/lib/react-native-version.js
+++ b/lib/react-native-version.js
@@ -3,6 +3,12 @@ const { pathOr, is } = require('ramda')
 // the default React Native version for this boilerplate
 const REACT_NATIVE_VERSION = '0.42.0'
 
+// where the version lives under gluegun
+const pathToVersion = ['parameters', 'options', 'react-native-version']
+
+// accepts the context and returns back the version
+const getVersionFromContext = pathOr(REACT_NATIVE_VERSION, pathToVersion)
+
 /**
  * Gets the React Native version to use.
  *
@@ -14,18 +20,8 @@ const REACT_NATIVE_VERSION = '0.42.0'
  * @param {*} context - The gluegun context.
  */
 const getReactNativeVersion = (context = {}) => {
-  // grab the user's choice (if any)
-  const value = pathOr(
-    REACT_NATIVE_VERSION,
-    ['parameters', 'options', 'react-native-version']
-  )(context)
-
-  // --react-native-version must be passed a string
-  if (!is(String, value)) {
-    return REACT_NATIVE_VERSION
-  }
-
-  return value
+  const version = getVersionFromContext(context)
+  return is(String, version) ? version : REACT_NATIVE_VERSION
 }
 
 module.exports = {

--- a/readme.md
+++ b/readme.md
@@ -2,17 +2,45 @@
 
 [![Build Status](https://semaphoreci.com/api/v1/ir/ignite-ir-boilerplate/branches/master/badge.svg)](https://semaphoreci.com/ir/ignite-ir-boilerplate)
 
+
+
 ## The latest and greatest boilerplate for Infinite Red opinions
 
 This is the boilerplate that [Infinite Red](https://infinite.red) uses as a way to test bleeding-edge changes to our React Native stack.
 
 Currently includes:
 
-* React Native 0.42.0
+* React Native 0.42.0 (but you can change this if you want to experiment)
 * React Navigation
 * Redux
 * Redux Sagas
 * And more!
+
+## Quick Start
+
+When you've installed the [Ignite CLI](https://github.com/infinitered/ignite), you can get started with this boilerplate like this:
+
+```
+ignite new MyLatestCreation
+```
+
+You can also change the React Native version, just keep in mind, we may not have tested this just yet.
+
+```sh
+ignite new MyLatestCreation --react-native-version 0.44.2
+```
+
+By default we'll ask you some questions during install as to which features you'd like.  If you just want them all, you can skip the questions:
+
+```sh
+ignite new MyLatestCreation --max
+```
+
+If you want very few of these extras:
+
+```sh
+ignite new MyLatestCreation --min
+```
 
 ## Boilerplate walkthrough
 

--- a/test/react-native-version.test.js
+++ b/test/react-native-version.test.js
@@ -1,0 +1,53 @@
+const boilerplate = require('../lib/react-native-version')
+
+// grab a few things from the boilerplate module
+const get = boilerplate.getReactNativeVersion
+const DEFAULT = boilerplate.REACT_NATIVE_VERSION
+
+/**
+ * Runs with a valid gluegun context and a staged version number.
+ *
+ * @param {*} reactNativeVersion The React Native version to use.
+ * @return {string} The version number we should be using.
+ */
+const mock = reactNativeVersion => get({
+  parameters: {
+    options: {
+      'react-native-version': reactNativeVersion
+    }
+  }
+})
+
+// this would only happen if we screwed something up in our boilerplate.js
+test('it handles strange inputs from code', () => {
+  expect(get()).toBe(DEFAULT)
+  expect(get(null)).toBe(DEFAULT)
+  expect(get(true)).toBe(DEFAULT)
+  expect(get(8)).toBe(DEFAULT)
+  expect(get('hello')).toBe(DEFAULT)
+  expect(get([])).toBe(DEFAULT)
+  expect(get({})).toBe(DEFAULT)
+  expect(get(() => true)).toBe(DEFAULT)
+})
+
+// this could happen because it's valid input via minimist from the user
+test('it handles strange input from the user', () => {
+  expect(mock(true)).toBe(DEFAULT)
+  expect(mock(false)).toBe(DEFAULT)
+  expect(mock([])).toBe(DEFAULT)
+  expect(mock({})).toBe(DEFAULT)
+})
+
+// very edge-casey
+test('it handles not-quite semver numbers', () => {
+  expect(mock(0)).toBe(DEFAULT)
+  expect(mock(0.25)).toBe(DEFAULT)
+})
+
+// happy path
+test('it handles valid versions', () => {
+  expect(mock('0.41.0')).toBe('0.41.0')
+  expect(mock('0.41.0-beta.1')).toBe('0.41.0-beta.1')
+  expect(mock(DEFAULT)).toBe(DEFAULT)
+  expect(mock('next')).toBe('next')
+})


### PR DESCRIPTION
Makes this a thing:

```sh
ignite new TheFuture --react-native-version 0.44.2
```

The boilerplate still recommends `0.42.0` (for now), but this allows people to do what they want.

