### PR TITLE
Upgrades to 0.42.3 which fixes upstream RN Android issues.

### DIFF
--- a/lib/react-native-version.js
+++ b/lib/react-native-version.js
@@ -1,7 +1,7 @@
 const { pathOr, is } = require('ramda')
 
 // the default React Native version for this boilerplate
-const REACT_NATIVE_VERSION = '0.42.0'
+const REACT_NATIVE_VERSION = '0.42.3'
 
 // where the version lives under gluegun
 const pathToVersion = ['parameters', 'options', 'react-native-version']


### PR DESCRIPTION
React Native 0.42.0 on Android is currently blowing up due to binaries in maven being nuked.

This allows us to dodge for now.

0.45 is coming out in a few days, so we'll likely skip up to that shortly.