### PR TITLE
Fix enzyme warnings

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -39,8 +39,8 @@
     "enzyme": "^2.6.0",
     "mockery": "^2.0.0",
     "husky": "^0.13.1",
-    "react-addons-test-utils": "^15.3.1",
-    "react-dom": "^15.4.0",
+    "react-addons-test-utils": "~15.4.1",
+    "react-dom": "~15.4.1",
     "reactotron-react-native": "^1.11.1",
     "reactotron-redux": "^1.11.1",
     "reactotron-redux-saga": "^1.11.1"


### PR DESCRIPTION
This fixes warnings displayed when running Component tests that reference Enzyme.

Here is the result of running tests before the fix:
![enzyme_warnings](https://cloud.githubusercontent.com/assets/144869/26660293/f24cfd36-462b-11e7-9763-299a573006b5.png)

Here is the result of running tests after the fix:
![fixed_enzyme_warnings](https://cloud.githubusercontent.com/assets/144869/26660302/00464ff0-462c-11e7-9946-6141db3ded09.png)
