### PR TITLE
Switching to functional setState in listview and examples

### DIFF
--- a/templates/examples/GridExample.js.ejs
+++ b/templates/examples/GridExample.js.ejs
@@ -73,9 +73,9 @@ class GridExample extends React.Component {
   * e.g.
     componentWillReceiveProps (newProps) {
       if (newProps.someData) {
-        this.setState({
-          dataSource: this.state.dataSource.cloneWithRows(newProps.someData)
-        })
+        this.setState(prevState => ({
+          dataSource: prevState.dataSource.cloneWithRows(newProps.someData)
+        }))
       }
     }
   *************************************************************/

--- a/templates/examples/RowExample.js.ejs
+++ b/templates/examples/RowExample.js.ejs
@@ -70,9 +70,9 @@ class RowExample extends React.Component {
   * e.g.
     componentWillReceiveProps (newProps) {
       if (newProps.someData) {
-        this.setState({
-          dataSource: this.state.dataSource.cloneWithRows(newProps.someData)
-        })
+        this.setState(prevState => ({
+          dataSource: prevState.dataSource.cloneWithRows(newProps.someData)
+        }))
       }
     }
   *************************************************************/

--- a/templates/examples/SectionExample.js.ejs
+++ b/templates/examples/SectionExample.js.ejs
@@ -90,9 +90,9 @@ class ListviewSectionsExample extends React.Component {
   * e.g.
     componentWillReceiveProps (newProps) {
       if (newProps.someData) {
-        this.setState({
-          dataSource: this.state.dataSource.cloneWithRowsAndSections(newProps.someData)
-        })
+        this.setState(prevState => ({
+          dataSource: prevState.dataSource.cloneWithRowsAndSections(newProps.someData)
+        }))
       }
     }
   *************************************************************/

--- a/templates/listview-sections.ejs
+++ b/templates/listview-sections.ejs
@@ -93,9 +93,9 @@ class ListviewSectionsExample extends React.Component {
   * e.g.
     componentWillReceiveProps (newProps) {
       if (newProps.someData) {
-        this.setState({
-          dataSource: this.state.dataSource.cloneWithRowsAndSections(newProps.someData)
-        })
+        this.setState(prevState => ({
+          dataSource: prevState.dataSource.cloneWithRowsAndSections(newProps.someData)
+        }))
       }
     }
   *************************************************************/

--- a/templates/listview.ejs
+++ b/templates/listview.ejs
@@ -75,9 +75,9 @@ class <%= props.name %> extends React.Component {
   * e.g.
     componentWillReceiveProps (newProps) {
       if (newProps.someData) {
-        this.setState({
-          dataSource: this.state.dataSource.cloneWithRows(newProps.someData)
-        })
+        this.setState(prevState => ({
+          dataSource: prevState.dataSource.cloneWithRows(newProps.someData)
+        }))
       }
     }
   *************************************************************/


### PR DESCRIPTION
Since state might be updated asynchronously, we shouldn't rely on it when calculating the next state. Instead we can pass setState a **function** that accepts the previous state and outputs a new state, rather than an **object** that references the current state as is currently implemented.

More info is available in the [React docs](https://facebook.github.io/react/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous) and [this article](https://medium.freecodecamp.com/functional-setstate-is-the-future-of-react-374f30401b6b).

Not trying to nitpick, especially since the only code changing is in comments, but figured since so many people learn RN using Ignite (like I did) it's might help someone out down the line to see a functional setState in action.