### PR TITLE
Bumps babel-plugin-ignite-ignore-reactotron.

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -41,7 +41,7 @@
     "husky": "^0.13.1",
     "react-addons-test-utils": "~15.4.1",
     "react-dom": "~15.4.1",
-    "babel-plugin-ignite-ignore-reactotron": "^0.2.0",
+    "babel-plugin-ignite-ignore-reactotron": "^0.3.0",
     "reactotron-react-native": "^1.11.1",
     "reactotron-redux": "^1.11.1",
     "reactotron-redux-saga": "^1.11.1"


### PR DESCRIPTION
Fix for when `console.tron.log()` appears in a `catch` block.

https://github.com/infinitered/babel-plugin-ignite-ignore-reactotron/pull/1