### PR TITLE
Bumps apisauce & ramda.

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -18,11 +18,11 @@
     "git-hook": "npm test -s"
   },
   "dependencies": {
-    "apisauce": "^0.10.0",
+    "apisauce": "^0.14.0",
     "format-json": "^1.0.3",
     "lodash": "^4.17.2",
     "querystringify": "0.0.4",
-    "ramda": "^0.23.0",
+    "ramda": "^0.24.1",
     "react-native-config": "^0.2.1",
     "react-native-device-info": "^0.10.0",
     "react-native-drawer": "^2.3.0",


### PR DESCRIPTION
`apisauce@<=0.14.0` didn't play nice with `react-native@0.45.1` because of a build-time 3rd party lib we were using in `apisauce` that mucking about with monkey patching global variables. 😨 

All fixed up and shipped... and this brings `ignite-ir-boilerplate` up as well.

(also snuck `ramda` in here as well since `apisauce` uses the latest there).
