### PR TITLE
removed appending of "Screen" to name, as the name already ends with "Screen"

### DIFF
--- a/templates/screen.ejs
+++ b/templates/screen.ejs
@@ -7,12 +7,12 @@ import { connect } from 'react-redux'
 // Styles
 import styles from './Styles/<%= props.name %>Style'
 
-class <%= props.name %>Screen extends React.Component {
+class <%= props.name %> extends React.Component {
   render () {
     return (
       <ScrollView style={styles.container}>
         <KeyboardAvoidingView behavior='position'>
-          <Text><%= props.name %> Screen</Text>
+          <Text><%= props.name %></Text>
         </KeyboardAvoidingView>
       </ScrollView>
     )
@@ -29,4 +29,4 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(<%= props.name %>Screen)
+export default connect(mapStateToProps, mapDispatchToProps)(<%= props.name %>)


### PR DESCRIPTION
After this change was commited:
https://github.com/infinitered/ignite-ir-boilerplate/commit/07d9eca7bbea251041422056d9cdc98f63f69498#diff-3a74efcd1a718d70ff863907651feec0, we need to remove the extra "Screen" that is appended to the name.

If I run the command
`ignite generate screen Testing`, 

the generated screen file will have 
`class TestingScreenScreen extends React.Component {`

This PR fixes this issue.