### PR TITLE
Fixed typos: celcius -> celsius, farenheit -> fahrenheit

### DIFF
--- a/boilerplate/App/Transforms/ConvertFromKelvin.js
+++ b/boilerplate/App/Transforms/ConvertFromKelvin.js
@@ -1,6 +1,6 @@
 export default (kelvin: number) => {
-  const celcius = kelvin - 273.15
-  const farenheit = (celcius * 1.8000) + 32
+  const celsius = kelvin - 273.15
+  const fahrenheit = (celsius * 1.8000) + 32
 
-  return Math.round(farenheit)
+  return Math.round(fahrenheit)
 }


### PR DESCRIPTION
Teeny tiny PR. Cheers