### PR TITLE
Fixed issue with nested reducers

### DIFF
--- a/boilerplate/App/Services/ImmutablePersistenceTransform.js
+++ b/boilerplate/App/Services/ImmutablePersistenceTransform.js
@@ -17,16 +17,6 @@ const toImmutable = (raw) => Immutable(raw)
 export default {
   out: (state) => {
     // console.log({ retrieving: state })
-    // --- HACKZORZ ---
-    // Attach a empty-ass function to the object called `mergeDeep`.
-    // This tricks redux-persist into just placing our Immutable object into the state tree
-    // instead of trying to convert it to a POJO
-    // https://github.com/rt2zz/redux-persist/blob/master/src/autoRehydrate.js#L55
-    //
-    // Another equal terrifying option would be to try to pass their other check
-    // which is lodash isPlainObject.
-    // --- END HACKZORZ ---
-    state.mergeDeep = R.identity
     return toImmutable(state)
   },
   in: (raw) => {


### PR DESCRIPTION
Fixes #77, which is related to [this issue](https://github.com/infinitered/ignite/issues/271) and it appears [this line](https://github.com/infinitered/ignite-ir-boilerplate/blob/7a08b490fb49e745401ed75bc2f5ac251f098bdf/boilerplate/App/Services/ImmutablePersistenceTransform.js#L29) that is causing it. As @skellock speculated, this seems unnecessary as of [this merge request](https://github.com/rt2zz/redux-persist/pull/216/files). Removing the line resolves the issue.