### PR TITLE
Adds a temp fix to repair broken rn preset.

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react-native": "2.0.0",
     "enzyme": "^2.6.0",
     "mockery": "^2.0.0",
     "husky": "^0.13.1",


### PR DESCRIPTION
So `babel-preset-react-native` is still broken/not-published upstream.

https://github.com/infinitered/ignite/issues/1098#issuecomment-315170624

This locks us to `2.0.0` which works.