### PR TITLE
Disabled git hooks to run tests

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -13,9 +13,10 @@
     "android:devices": "$ANDROID_HOME/platform-tools/adb devices",
     "android:logcat": "$ANDROID_HOME/platform-tools/adb logcat *:S ReactNative:V ReactNativeJS:V",
     "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82",
-    "precommit": "npm run git-hook",
-    "prepush": "npm run git-hook",
-    "git-hook": "npm test -s"
+    <%# Commented out to disable tests until Enzyme becomes compatible with newer React Native versions: %>
+    <%# "precommit": "npm run git-hook", %>
+    <%# "prepush": "npm run git-hook", %>
+    <%# "git-hook": "npm test -s" %>
   },
   "dependencies": {
     "apisauce": "^0.14.0",

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -13,10 +13,10 @@
     "android:devices": "$ANDROID_HOME/platform-tools/adb devices",
     "android:logcat": "$ANDROID_HOME/platform-tools/adb logcat *:S ReactNative:V ReactNativeJS:V",
     "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82",
-    <%# Commented out to disable tests until Enzyme becomes compatible with newer React Native versions: %>
-    <%# "precommit": "npm run git-hook", %>
-    <%# "prepush": "npm run git-hook", %>
-    <%# "git-hook": "npm test -s" %>
+    <% /* Commented out to disable tests until Enzyme becomes compatible with newer React Native versions:
+    "precommit": "npm run git-hook",
+    "prepush": "npm run git-hook",
+    "git-hook": "npm test -s" */ %>
   },
   "dependencies": {
     "apisauce": "^0.14.0",

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -12,8 +12,9 @@
     "android:hockeyapp": "cd android && ./gradlew assembleRelease && puck -submit=auto app/build/outputs/apk/app-release.apk",
     "android:devices": "$ANDROID_HOME/platform-tools/adb devices",
     "android:logcat": "$ANDROID_HOME/platform-tools/adb logcat *:S ReactNative:V ReactNativeJS:V",
-    "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82",
+    "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82"
     <% /* Commented out to disable tests until Enzyme becomes compatible with newer React Native versions:
+    ,
     "precommit": "npm run git-hook",
     "prepush": "npm run git-hook",
     "git-hook": "npm test -s" */ %>


### PR DESCRIPTION
Disabled git hooks to run tests in precommit and prepush until Enzyme becomes compatible with newer React Native versions. See issue 1109 in ignite: https://github.com/infinitered/ignite/issues/1109

I hope the format is correct. I have no idea if comments (or generally tags) can be multiline in ejs. I Couldn't find anything about it in the docs, which are pretty short :)