### PR TITLE
Add askToOverride to default config.

### DIFF
--- a/boilerplate/ignite.json.ejs
+++ b/boilerplate/ignite.json.ejs
@@ -1,5 +1,6 @@
 {
   "createdWith": "<%= props.igniteVersion %>",
   "examples": "classic",
-  "navigation": "react-navigation"
+  "navigation": "react-navigation",
+  "askToOverride": true
 }


### PR DESCRIPTION
Sets askToOverride to true in the default config. Without, its possible to overwrite previously generated components if you re-run the ignite generate action a second time.  Seems to be the expected behavior and thus better for the default.

Refers to Issue [1120](https://github.com/infinitered/ignite/issues/1120)