### PR TITLE
Modification of the yeld due to an obsolete manner

### DIFF
--- a/boilerplate/App/Sagas/index.js
+++ b/boilerplate/App/Sagas/index.js
@@ -1,4 +1,4 @@
-import { takeLatest } from 'redux-saga/effects'
+import { takeLatest, all } from 'redux-saga/effects'
 import API from '../Services/Api'
 import FixtureAPI from '../Services/FixtureApi'
 import DebugConfig from '../Config/DebugConfig'
@@ -22,11 +22,11 @@ const api = DebugConfig.useFixtures ? FixtureAPI : API.create()
 /* ------------- Connect Types To Sagas ------------- */
 
 export default function * root () {
-  yield [
+  yield all([
     // some sagas only receive an action
     takeLatest(StartupTypes.STARTUP, startup),
 
     // some sagas receive extra parameters in addition to an action
     takeLatest(GithubTypes.USER_REQUEST, getUserAvatar, api)
-  ]
+  ])
 }


### PR DESCRIPTION
Because of the following error message: `[...effects] has been deprecated in favor of all([...effects]), please update your code` (see redux-saga/redux-saga#960), the code needs to be updated (I know, very small contribution 😄).