### PR TITLE
Introduce Storybook into Ignite (Take Two)

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -54,7 +54,7 @@ async function install (context) {
   // remove the __tests__ directory that come with React Native
   filesystem.remove('__tests__')
 
-  // copy our App & Tests directories
+  // copy our App, Tests & storybook directories
   spinner.text = '▸ copying files'
   spinner.start()
   filesystem.copy(`${__dirname}/boilerplate/App`, `${process.cwd()}/App`, {
@@ -62,6 +62,10 @@ async function install (context) {
     matching: '!*.ejs'
   })
   filesystem.copy(`${__dirname}/boilerplate/Tests`, `${process.cwd()}/Tests`, {
+    overwrite: true,
+    matching: '!*.ejs'
+  })
+  filesystem.copy(`${__dirname}/boilerplate/storybook`, `${process.cwd()}/storybook`, {
     overwrite: true,
     matching: '!*.ejs'
   })
@@ -86,7 +90,8 @@ async function install (context) {
     { template: 'ignite.json.ejs', target: 'ignite/ignite.json' },
     { template: '.editorconfig', target: '.editorconfig' },
     { template: '.babelrc', target: '.babelrc' },
-    { template: 'Tests/Setup.js.ejs', target: 'Tests/Setup.js' }
+    { template: 'Tests/Setup.js.ejs', target: 'Tests/Setup.js' },
+    { template: 'storybook/storybook.ejs', target: 'storybook/storybook.js' }
   ]
   const templateProps = {
     name,

--- a/boilerplate/App/Components/AlertMessage.story.js
+++ b/boilerplate/App/Components/AlertMessage.story.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react-native'
+
+import AlertMessage from './AlertMessage'
+
+storiesOf('AlertMessage')
+  .add('Default', () => (
+    <AlertMessage
+      title='ALERT ALERT'
+    />
+  ))
+  .add('Hidden', () => (
+    <AlertMessage
+      title='ALERT ALERT'
+      show={false}
+    />
+  ))
+  .add('Custom Style', () => (
+    <AlertMessage
+      title='ALERT ALERT'
+      style={{ backgroundColor: 'red' }}
+    />
+  ))

--- a/boilerplate/App/Components/DrawerButton.story.js
+++ b/boilerplate/App/Components/DrawerButton.story.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { View } from 'react-native'
+import { storiesOf } from '@storybook/react-native'
+
+import DrawerButton from './DrawerButton'
+
+storiesOf('DrawerButton')
+  .add('Default', () => (
+    <View style={{ backgroundColor: 'black' }}>
+      <DrawerButton
+        text='Drawer Button'
+        onPress={() => { }}
+      />
+    </View>
+  ))

--- a/boilerplate/App/Components/FullButton.story.js
+++ b/boilerplate/App/Components/FullButton.story.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react-native'
+
+import FullButton from './FullButton'
+
+storiesOf('FullButton')
+  .add('Default', () => (
+    <FullButton
+      text='A simple button'
+    />
+  ))
+  .add('Custom Style', () => (
+    <FullButton
+      text='Style Me Up!'
+      styles={{ backgroundColor: 'blue' }}
+    />
+  ))

--- a/boilerplate/App/Components/RoundedButton.story.js
+++ b/boilerplate/App/Components/RoundedButton.story.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react-native'
+
+import RoundedButton from './RoundedButton'
+
+storiesOf('RoundedButton')
+  .add('Default', () => (
+    <RoundedButton
+      text='A simple rounded button'
+    />
+  ))
+  .add('Text as children', () => (
+    <RoundedButton>
+        Hello from the children!
+    </RoundedButton>
+  ))

--- a/boilerplate/App/Components/SearchBar.story.js
+++ b/boilerplate/App/Components/SearchBar.story.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { View } from 'react-native'
+import { storiesOf } from '@storybook/react-native'
+
+import SearchBar from './SearchBar'
+
+storiesOf('SearchBar')
+  .add('Default', () => (
+    <View style={{ backgroundColor: 'black', height: 50 }}>
+      <SearchBar
+        onSearch={() => {}}
+        onCancel={() => {}}
+      />
+    </View>
+  ))
+  .add('With Search Term', () => (
+    <View style={{ backgroundColor: 'black', height: 50 }}>
+      <SearchBar
+        onSearch={() => {}}
+        onCancel={() => {}}
+        searchTerm='HELLO!!'
+      />
+    </View>
+  ))

--- a/boilerplate/App/Components/Stories.js
+++ b/boilerplate/App/Components/Stories.js
@@ -1,0 +1,2 @@
+import './FullButton.story'
+import './RoundedButton.story'

--- a/boilerplate/App/Components/Stories.js
+++ b/boilerplate/App/Components/Stories.js
@@ -1,2 +1,5 @@
+import './AlertMessage.story'
+import './DrawerButton.story'
 import './FullButton.story'
 import './RoundedButton.story'
+import './SearchBar.story'

--- a/boilerplate/Tests/StoriesTest.js
+++ b/boilerplate/Tests/StoriesTest.js
@@ -1,0 +1,3 @@
+import initStoryshots from '@storybook/addon-storyshots'
+
+initStoryshots()

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -12,7 +12,8 @@
     "android:hockeyapp": "cd android && ./gradlew assembleRelease && puck -submit=auto app/build/outputs/apk/app-release.apk",
     "android:devices": "$ANDROID_HOME/platform-tools/adb devices",
     "android:logcat": "$ANDROID_HOME/platform-tools/adb logcat *:S ReactNative:V ReactNativeJS:V",
-    "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82"
+    "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82",
+    "storybook": "storybook start -p 7007"
     <% /* Commented out to disable tests until Enzyme becomes compatible with newer React Native versions:
     ,
     "precommit": "npm run git-hook",
@@ -38,6 +39,8 @@
     "seamless-immutable": "^7.0.1"
   },
   "devDependencies": {
+    "@storybook/addon-storyshots": "^3.2.3",
+    "@storybook/react-native": "^3.2.3",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react-native": "2.0.0",
     "enzyme": "^2.6.0",

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -47,7 +47,7 @@
     "mockery": "^2.0.0",
     "husky": "^0.13.1",
     "react-addons-test-utils": "~15.4.1",
-    "react-dom": "~15.4.1",
+    "react-dom": "16.0.0-alpha.12",
     "babel-plugin-ignite-ignore-reactotron": "^0.3.0",
     "reactotron-react-native": "^1.12.0",
     "reactotron-redux": "^1.11.1",

--- a/boilerplate/storybook/addons.js
+++ b/boilerplate/storybook/addons.js
@@ -1,0 +1,2 @@
+import '@storybook/addon-actions/register'
+import '@storybook/addon-links/register'

--- a/boilerplate/storybook/index.android.js
+++ b/boilerplate/storybook/index.android.js
@@ -1,0 +1,3 @@
+import StorybookUI from './storybook'
+
+export default StorybookUI

--- a/boilerplate/storybook/index.ios.js
+++ b/boilerplate/storybook/index.ios.js
@@ -1,0 +1,3 @@
+import StorybookUI from './storybook'
+
+export default StorybookUI

--- a/boilerplate/storybook/storybook.ejs
+++ b/boilerplate/storybook/storybook.ejs
@@ -1,0 +1,13 @@
+import { AppRegistry } from 'react-native'
+import { getStorybookUI, configure } from '@storybook/react-native'
+
+// import stories
+configure(() => {
+  require('../App/Components/stories')
+}, module)
+
+// This assumes that storybook is running on the same host as your RN packager,
+// to set manually use, e.g. host: 'localhost' option
+const StorybookUI = getStorybookUI({ port: 7007, onDeviceUI: true })
+AppRegistry.registerComponent('<%= props.name %>', () => StorybookUI)
+export default StorybookUI

--- a/boilerplate/storybook/storybook.ejs
+++ b/boilerplate/storybook/storybook.ejs
@@ -3,7 +3,7 @@ import { getStorybookUI, configure } from '@storybook/react-native'
 
 // import stories
 configure(() => {
-  require('../App/Components/stories')
+  require('../App/Components/Stories')
 }, module)
 
 // This assumes that storybook is running on the same host as your RN packager,

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,10 @@ Your primary and other navigation components reside here.
 
 React components go here...pretty self-explanatory. We won't go through each in detail -- open each file to read the comments and view the code.
 
+### Storybook
+
+[Storybook](https://storybook.js.org/) has been setup to show off components in the different states. Storybook is a great way to develop and test components outside of use in your app. Simply run `npm run storybook` to get started. All stores are contained in the `*.story.js` files along side the components.
+
 ### Themes
 
 Styling themes used throughout your app styles.


### PR DESCRIPTION
In this PR I introduce Storybook and Storyshots to the core of the boilerplate and setup two basic stories against some components that ship with the boilerplate. I am adding this as I believe Storybook and Storyshots to be fantastic tools when building out a set of components like many end users of this boilerplate will be doing. This is not meant to be complete but rather a glimpse into what this type of integration could look like. If it is liked I can finish out writing the component stories so all components ship with storybook stories.

# What was added
Two new dependencies for Storybook and Storyshots, a storybook script, a few stories for existing components in the boilerplate, a stories test to run storyshots and the support storybook folder to help run storybook

# What needs to be done
- Write more stories
- Possibly clean up the implementation into the boilerplate
- Docs around storybook and storyshots
- Make sure storyshots runs on precommit or prepush hooks to ensure snapshots did not change

# What does this look like?
This is what Storybook looks like:
![screen shot 2017-08-03 at 7 37 56 pm](https://user-images.githubusercontent.com/14151327/28948376-480ed850-7883-11e7-9443-fa1576199498.png)

For storyshots I will note pollute you with a snapshot file so I will just say that it generates your typical Jest snapshot for each and every story defined.

# How do you test it?
Storybook: Instead of running `(npm/yarn) start` in the project directory you run `(npm/yarn) run storybook` then launch the app normally (via `react-native run-ios` and `react-native run-android`). ANDROID NOTE: You will need to run `adb reverse tcp:7007 tcp:7007` before launching the app to ensure port 7007 is tunneled back to your computer

Storyshots: `npm test` will run the snapshot tests setup for stories.

@GantMan I was not getting the other branch to allow for an auto merge so trying to do a different branch with all the same changes.