### PR TITLE
Upgrade to RN 0.47.2

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -34,7 +34,7 @@
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
     "redux-persist": "^4.1.0",
-    "redux-saga": "^0.14.3",
+    "redux-saga": "^0.15.6",
     "reduxsauce": "0.4.1",
     "seamless-immutable": "^7.0.1"
   },

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -42,7 +42,7 @@
     "@storybook/addon-storyshots": "^3.2.3",
     "@storybook/react-native": "^3.2.3",
     "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react-native": "2.0.0",
+    "babel-preset-react-native": "3.0.2",
     "enzyme": "^2.6.0",
     "mockery": "^2.0.0",
     "husky": "^0.13.1",

--- a/lib/react-native-version.js
+++ b/lib/react-native-version.js
@@ -1,7 +1,7 @@
 const { pathOr, is } = require('ramda')
 
 // the default React Native version for this boilerplate
-const REACT_NATIVE_VERSION = '0.45.1'
+const REACT_NATIVE_VERSION = '0.47.2'
 
 // where the version lives under gluegun
 const pathToVersion = ['parameters', 'options', 'react-native-version']

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ This is the boilerplate that [Infinite Red](https://infinite.red) uses as a way 
 
 Currently includes:
 
-* React Native 0.45.1 (but you can change this if you want to experiment)
+* React Native 0.47.2 (but you can change this if you want to experiment)
 * React Navigation
 * Redux
 * Redux Sagas


### PR DESCRIPTION
Upgrades the boilerplate to RN 0.47.2

Due to various errors, also updates redux-saga and babel-preset-react-native

The app runs out of the box, tests pass, all default plugins work, dev screens work, generators seem to work. If there's anything else that should be tested, let me know. 

ignite-maps will break with this change (See https://github.com/airbnb/react-native-maps/issues/1193), so we should upgrade the version of react-native-maps once this is released.