### PR TITLE
Flatlist yellowbox removed

### DIFF
--- a/commands/list.js
+++ b/commands/list.js
@@ -69,16 +69,36 @@ module.exports = async function (context) {
     dataType = dataAnswers.type
   }
 
-  // set appropriate templates to generate
-  let componentTemplate = typeCode.toLowerCase() === 'flatlist'
-    ? 'flatlist'
-    : 'listview'
-  componentTemplate = dataType.toLowerCase() === 'sectioned'
-    ? componentTemplate + '-sections'
-    : componentTemplate
-  const styleTemplate = type.toLowerCase() === 'grid'
-    ? 'listview-grid-style'
-    : 'listview-style'
+  // Sorry the following is so confusing, but so are React Native lists
+  // There are 3 options and therefore 8 possible combinations
+  let componentTemplate = dataType.toLowerCase() === 'sectioned'
+    ? typeCode + '-sections'
+    : typeCode
+  let styleTemplate = ''
+  // Different logic depending on code types
+  if (typeCode === 'flatlist') {
+
+    /*
+    * The following mess is because FlatList supports numColumns
+    * where SectionList does not.
+    */
+    if (type.toLowerCase() === 'grid' && dataType.toLowerCase() === 'sectioned') {
+      // grid + section means we need wrap
+      styleTemplate = 'listview-grid-style'
+    } else if (type.toLowerCase() === 'grid') {
+      componentTemplate = componentTemplate + '-grid'
+      // grid + single = no wrap, use columns
+      styleTemplate = 'flatlist-grid-style'
+    } else {
+      // no grids, flatlist basic
+      styleTemplate = 'listview-style'
+    }
+  } else {
+    // listview builder
+    styleTemplate = type.toLowerCase() === 'grid'
+      ? 'listview-grid-style'
+      : 'listview-style'
+  }
 
   const jobs = [
     {

--- a/commands/list.js
+++ b/commands/list.js
@@ -77,7 +77,6 @@ module.exports = async function (context) {
   let styleTemplate = ''
   // Different logic depending on code types
   if (typeCode === 'flatlist') {
-
     /*
     * The following mess is because FlatList supports numColumns
     * where SectionList does not.

--- a/templates/flatlist-grid-style.ejs
+++ b/templates/flatlist-grid-style.ejs
@@ -1,0 +1,34 @@
+import { StyleSheet } from 'react-native'
+import { ApplicationStyles, Metrics, Colors } from '../../Themes'
+
+export default StyleSheet.create({
+  ...ApplicationStyles.screen,
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background
+  },
+  row: {
+    flex: 1,
+    backgroundColor: Colors.fire,
+    marginVertical: Metrics.smallMargin,
+    justifyContent: 'center',
+    margin: 10,
+    padding: 5,
+    paddingVertical: 10,
+    borderRadius: Metrics.smallMargin
+  },
+  boldLabel: {
+    fontWeight: 'bold',
+    alignSelf: 'center',
+    color: Colors.snow,
+    textAlign: 'center',
+    marginBottom: Metrics.smallMargin
+  },
+  label: {
+    textAlign: 'center',
+    color: Colors.snow
+  },
+  listContent: {
+    marginTop: Metrics.baseMargin
+  }
+})

--- a/templates/flatlist-grid.ejs
+++ b/templates/flatlist-grid.ejs
@@ -1,0 +1,118 @@
+import React from 'react'
+import { View, Text, FlatList } from 'react-native'
+import { connect } from 'react-redux'
+
+// More info here: https://facebook.github.io/react-native/docs/flatlist.html
+
+// Styles
+import styles from './Styles/<%= props.name %>Style'
+
+class <%= props.name %> extends React.PureComponent {
+  /* ***********************************************************
+  * STEP 1
+  * This is an array of objects with the properties you desire
+  * Usually this should come from Redux mapStateToProps
+  *************************************************************/
+  state = {
+    dataObjects: [
+      {title: 'First Title', description: 'First Description'},
+      {title: 'Second Title', description: 'Second Description'},
+      {title: 'Third Title', description: 'Third Description'},
+      {title: 'Fourth Title', description: 'Fourth Description'},
+      {title: 'Fifth Title', description: 'Fifth Description'},
+      {title: 'Sixth Title', description: 'Sixth Description'},
+      {title: 'Seventh Title', description: 'Seventh Description'}
+    ]
+  }
+
+  /* ***********************************************************
+  * STEP 2
+  * `renderRow` function. How each cell/row should be rendered
+  * It's our best practice to place a single component here:
+  *
+  * e.g.
+    return <MyCustomCell title={item.title} description={item.description} />
+  *************************************************************/
+  renderRow ({item}) {
+    return (
+      <View style={styles.row}>
+        <Text style={styles.boldLabel}>{item.title}</Text>
+        <Text style={styles.label}>{item.description}</Text>
+      </View>
+    )
+  }
+
+  /* ***********************************************************
+  * STEP 3
+  * Consider the configurations we've set below.  Customize them
+  * to your liking!  Each with some friendly advice.
+  *************************************************************/
+  // Render a header?
+  renderHeader = () =>
+    <Text style={[styles.label, styles.sectionHeader]}> - Header - </Text>
+
+  // Render a footer?
+  renderFooter = () =>
+    <Text style={[styles.label, styles.sectionHeader]}> - Footer - </Text>
+
+  // Show this when data is empty
+  renderEmpty = () =>
+    <Text style={styles.label}> - Nothing to See Here - </Text>
+
+  renderSeparator = () =>
+    <Text style={styles.label}> - ~~~~~ - </Text>
+
+  // The default function if no Key is provided is index
+  // an identifiable key is important if you plan on
+  // item reordering.  Otherwise index is fine
+  keyExtractor = (item, index) => index
+
+  // How many items should be kept im memory as we scroll?
+  oneScreensWorth = 20
+
+  // extraData is for anything that is not indicated in data
+  // for instance, if you kept "favorites" in `this.state.favs`
+  // pass that in, so changes in favorites will cause a re-render
+  // and your renderItem will have access to change depending on state
+  // e.g. `extraData`={this.state.favs}
+
+  // Optimize your list if the height of each item can be calculated
+  // by supplying a constant height, there is no need to measure each
+  // item after it renders.  This can save significant time for lists
+  // of a size 100+
+  // e.g. itemLayout={(data, index) => (
+  //   {length: ITEM_HEIGHT, offset: ITEM_HEIGHT * index, index}
+  // )}
+
+  render () {
+    return (
+      <View style={styles.container}>
+        <FlatList
+          contentContainerStyle={styles.listContent}
+          data={this.state.dataObjects}
+          renderItem={this.renderRow}
+          numColumns={2}
+          keyExtractor={this.keyExtractor}
+          initialNumToRender={this.oneScreensWorth}
+          ListHeaderComponent={this.renderHeader}
+          ListFooterComponent={this.renderFooter}
+          ListEmptyComponent={this.renderEmpty}
+          ItemSeparatorComponent={this.renderSeparator}
+        />
+      </View>
+    )
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    // ...redux state to props here
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(<%= props.name %>)


### PR DESCRIPTION
flatlist grid is completely different logic than anything else, and was causing a yellowbox on RN 0.47.2

### Things to note:
1. This PR fixes flatlist grids
2. You still get yellowbox on Sectioned Grids.  I have filed a ticket here on RN: https://github.com/facebook/react-native/issues/15772
3. Listview Sectioned Grids stopped working at some point... I'm not including the fix or taking it into account here, but this appears to be a regression, and probably needs an upstream ticket.  Unless someone (@fvonhoven et al.)  can figure out a new way to get it working.   The stack overflow solution (which was the same as our solution) nolonger works.