### PR TITLE
fix test setup from missing dependency

### DIFF
--- a/boilerplate/Tests/Setup.js.ejs
+++ b/boilerplate/Tests/Setup.js.ejs
@@ -1,8 +1,6 @@
-jest
-.mock('react-native-device-info', () => {
-  return { isTablet: jest.fn(() => { return false }) }
-})
+// Mock your external modules here if needed
 <%_ if (props.i18n === 'react-native-i18n') { _%>
+jest
 .mock('react-native-i18n', () => {
   const english = require('../App/I18n/languages/english.json')
   const keys = require('ramda')
@@ -22,4 +20,9 @@ jest
     }
   }
 })
+<%_ } else { _%>
+// jest
+// .mock('react-native-device-info', () => {
+//   return { isTablet: jest.fn(() => { return false }) }
+// })
 <%_ } _%>


### PR DESCRIPTION
react-native-device-info was removed in https://github.com/infinitered/ignite-ir-boilerplate/commit/6fe2841aac81715f950bce2664e4bda8c58170d3, so the test setup was failing on a fresh-from-the-oven app 

I left it commented as an example in case someone wondered what that file is for (it just says jest if you don't use i18n).