### PR TITLE
FT - add ReduxDevTools support 

### DIFF
--- a/boilerplate/App/Config/DebugConfig.js
+++ b/boilerplate/App/Config/DebugConfig.js
@@ -4,5 +4,6 @@ export default {
   yellowBox: __DEV__,
   reduxLogging: __DEV__,
   includeExamples: __DEV__,
-  useReactotron: __DEV__
+  useReactotron: __DEV__,
+  useReduxDevTools: false
 }

--- a/boilerplate/App/Redux/CreateStore.js
+++ b/boilerplate/App/Redux/CreateStore.js
@@ -36,7 +36,7 @@ export default (rootReducer, rootSaga) => {
 
   // if Reactotron is enabled (default for __DEV__), we'll create the store through Reactotron
   const createAppropriateStore = Config.useReactotron ? console.tron.createStore : createStore
-  const composer = Config.useReduxDevTools ? composeWithDevTools({hostname: Config.reduxDevToolsHostname, port: Config.reduxDevToolsPort }) : compose
+  const composer = Config.useReduxDevTools ? composeWithDevTools({hostname: 'remotedev.io'}) : compose
   const store = createAppropriateStore(rootReducer, compose(...enhancers))
 
   // configure persistStore and check reducer version number

--- a/boilerplate/App/Redux/CreateStore.js
+++ b/boilerplate/App/Redux/CreateStore.js
@@ -5,6 +5,7 @@ import createSagaMiddleware from 'redux-saga'
 import RehydrationServices from '../Services/RehydrationServices'
 import ReduxPersist from '../Config/ReduxPersist'
 import ScreenTracking from './ScreenTrackingMiddleware'
+import { composeWithDevTools } from 'remote-redux-devtools'
 
 // creates the store
 export default (rootReducer, rootSaga) => {
@@ -35,6 +36,7 @@ export default (rootReducer, rootSaga) => {
 
   // if Reactotron is enabled (default for __DEV__), we'll create the store through Reactotron
   const createAppropriateStore = Config.useReactotron ? console.tron.createStore : createStore
+  const composer = Config.useReduxDevTools ? composeWithDevTools({hostname: Config.reduxDevToolsHostname, port: Config.reduxDevToolsPort }) : compose
   const store = createAppropriateStore(rootReducer, compose(...enhancers))
 
   // configure persistStore and check reducer version number

--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -47,6 +47,7 @@
     "husky": "^0.13.1",
     "react-addons-test-utils": "~15.4.1",
     "react-dom": "16.0.0-alpha.12",
+    "remote-redux-devtools": "^0.5.12",
     "babel-plugin-ignite-ignore-reactotron": "^0.3.0",
     "reactotron-react-native": "^1.12.0",
     "reactotron-redux": "^1.11.1",


### PR DESCRIPTION
We set default to false as we use remotedev.io, some people don't want to have their state automatically communicated to a third party.
You can just use a local server with https://github.com/zalmoxisus/remotedev-server
Works with chrome extension