### PR TITLE
Added support for generating components into subfolders

### DIFF
--- a/commands/component.js
+++ b/commands/component.js
@@ -15,21 +15,23 @@ module.exports = async function (context) {
   }
 
   // read some configuration
-  const name = pascalCase(parameters.first)
+  let pathComponents = parameters.first.split('/').map(pascalCase)
+  const name = pathComponents.pop()
+  const subFolder = pathComponents.length ? pathComponents.join('/') + '/' : ''
   const props = { name }
   const jobs = [
     {
       template: 'component.ejs',
-      target: `App/Components/${name}.js`
+      target: `App/Components/${subFolder}${name}.js`
     },
     {
       template: 'component-style.ejs',
-      target: `App/Components/Styles/${name}Style.js`
+      target: `App/Components/${subFolder}Styles/${name}Style.js`
     },
     tests === 'ava' &&
       {
         template: 'component-test.ejs',
-        target: `Test/Components/${name}Test.js`
+        target: `Test/Components/${subFolder}${name}Test.js`
       }
   ]
 

--- a/test/generators-integration.test.js
+++ b/test/generators-integration.test.js
@@ -38,6 +38,14 @@ describe('generators', () => {
     expect(lint.stderr).toBe('')
   })
 
+  test('generates a component in sub folder', async () => {
+    await execa(IGNITE, ['g', 'component', 'My/SubFolder/Test'], { preferLocal: false })
+    expect(jetpack.exists('App/Components/My/SubFolder/Test.js')).toBe('file')
+    expect(jetpack.exists('App/Components/My/SubFolder/Styles/TestStyle.js')).toBe('file')
+    const lint = await execa('npm', ['-s', 'run', 'lint'])
+    expect(lint.stderr).toBe('')
+  })
+
   test('generate listview of type row works', async () => {
     await execa(IGNITE, ['g', 'list', 'TestRow', '--type=Row', '--codeType=listview', '--dataType=Single'], { preferLocal: false })
     expect(jetpack.exists('App/Containers/TestRow.js')).toBe('file')


### PR DESCRIPTION
Addressing infinitered/ignite#996. It will make this possible:

`ignite generate component Custom/Path/MyComponent`

Which will result in:
`App/Components/Custom/Path/MyComponent.js`
`App/Components/Custom/Path/Styles/MyComponentStyle.js`

However it is for Components only so far. There are relative paths to the Themes folder in Container templates e.t.c. which would be messy to update dynamically. Could we change them to absolute paths?
