### PR TITLE
upgrade react-native to v0.49.3

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -51,8 +51,9 @@ async function install (context) {
   })
   if (rnInstall.exitCode > 0) process.exit(rnInstall.exitCode)
 
-  // remove the __tests__ directory that come with React Native
+  // remove the __tests__ directory and App.js that come with React Native
   filesystem.remove('__tests__')
+  filesystem.remove('App.js')
 
   // copy our App, Tests & storybook directories
   spinner.text = '▸ copying files'
@@ -84,8 +85,7 @@ async function install (context) {
   // generate some templates
   spinner.text = '▸ generating files'
   const templates = [
-    { template: 'index.js.ejs', target: 'index.ios.js' },
-    { template: 'index.js.ejs', target: 'index.android.js' },
+    { template: 'index.js.ejs', target: 'index.js' },
     { template: 'README.md', target: 'README.md' },
     { template: 'ignite.json.ejs', target: 'ignite/ignite.json' },
     { template: '.editorconfig', target: '.editorconfig' },

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -176,7 +176,7 @@ async function install (context) {
 
     // now run install of Ignite Plugins
     if (answers['dev-screens'] === 'Yes') {
-      await system.spawn(`ignite add dev-screens@"~>2.0.0" ${debugFlag}`, {
+      await system.spawn(`ignite add dev-screens@"~>2.2.0" ${debugFlag}`, {
         stdio: 'inherit'
       })
     }

--- a/lib/react-native-version.js
+++ b/lib/react-native-version.js
@@ -1,7 +1,7 @@
 const { pathOr, is } = require('ramda')
 
 // the default React Native version for this boilerplate
-const REACT_NATIVE_VERSION = '0.47.2'
+const REACT_NATIVE_VERSION = '0.49.3'
 
 // where the version lives under gluegun
 const pathToVersion = ['parameters', 'options', 'react-native-version']


### PR DESCRIPTION
One big change is that RN now uses a single index.js and App.js entrypoint (https://github.com/facebook/react-native/commit/6e99e314b232c315628c31f97a865c17c071ad23).

Another big change is that PropTypes is now officially out.  This means the dev-screens result in a Red Box until https://github.com/infinitered/ignite-dev-screens/pull/7 is merged and a new release is made.