### PR TITLE
fixes .env copy location message

### DIFF
--- a/boilerplate/.env.example
+++ b/boilerplate/.env.example
@@ -1,4 +1,4 @@
-# This is an example where you can store your environment variables. Copy this file to ./App/Config/.env
+# This is an example where you can store your environment variables. Copy this file to .env
 # Now your app will have access to the variables added below. 
 # For more instructions see section "Secrets" in README.md
 


### PR DESCRIPTION
If the file is located inside previous path the `.env` file is never loaded. 
The file must be placed in the root path just like it says in the Readme.

>### Get started:
>1. **Copy .env.example to .env**