### PR TITLE
Remove .env.example from gitignore

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -114,7 +114,6 @@ async function install (context) {
   filesystem.appendAsync('.gitattributes', '*.bat text eol=crlf')
   filesystem.append('.gitignore', '\n# Misc\n#')
   filesystem.append('.gitignore', '\n.env.example\n')
-  filesystem.append('.gitignore', '.env\n')
 
   /**
    * Merge the package.json from our template into the one provided from react-native init.


### PR DESCRIPTION
At the moment the `.env` file is ignored by Git. It shouldn't. This removes it from `.gitignore`.