### PR TITLE
Fixes  FAIL  Tests/StoriesTest.js

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -23,6 +23,7 @@
   "dependencies": {
     "apisauce": "^0.14.0",
     "format-json": "^1.0.3",
+    "identity-obj-proxy": "^3.0.0",
     "lodash": "^4.17.2",
     "prop-types": "^15.5.10",
     "querystringify": "0.0.4",
@@ -60,6 +61,9 @@
       "/node_modules/",
       "Tests/Setup.js"
     ],
+    "moduleNameMapper": {
+      "^.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "identity-obj-proxy"
+    },
     "setupFiles": [
       "./Tests/Setup"
     ],


### PR DESCRIPTION
  ● Test suite failed to run

    /node_modules/@storybook/react-native/dist/preview/components/OnDeviceUI/menu_open.png:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){�PNG
                                                                                             ^

    SyntaxError: Invalid or unexpected token

      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/script_transformer.js:303:17)
      at Object.<anonymous> (node_modules/@storybook/react-native/dist/preview/components/OnDeviceUI/index.js:51:21)
      at Object.<anonymous> (node_modules/@storybook/react-native/dist/preview/index.js:47:19)