### PR TITLE
fixes #169 : "testMatch not working properly"

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -53,15 +53,15 @@
   },
   "jest": {
     "testMatch": [
-      "**/Tests/**/*.js",
+      "<rootDir>/Tests/**/*.js",
       "**/?(*.)(spec|test).js?(x)"
     ],
     "testPathIgnorePatterns":[
       "/node_modules/",
-      "Tests/Setup.js"
+      "<rootDir>/Tests/Setup.js"
     ],
     "setupFiles": [
-      "./Tests/Setup"
+      "<rootDir>/Tests/Setup"
     ],
     "preset": "react-native"
   },


### PR DESCRIPTION
If the route to the folder where we have the project had a folder named `Tests`( e.g. `~/Documents/Tests/MyAwesomeProject`), Jest was looking for tests outside the `<root>/Tests` folder.