### PR TITLE
Remove data prop from SectionList

### DIFF
--- a/templates/flatlist-sections.ejs
+++ b/templates/flatlist-sections.ejs
@@ -139,7 +139,6 @@ class <%= props.name %> extends React.PureComponent {
           renderSectionHeader={this.renderSectionHeader}
           sections={this.state.data}
           contentContainerStyle={styles.listContent}
-          data={this.state.dataObjects}
           renderItem={this.renderItem}
           keyExtractor={this.keyExtractor}
           initialNumToRender={this.oneScreensWorth}


### PR DESCRIPTION
no data prop for SectionList (the "data" property is sections)
`data={this.state.dataObjects}` - probably leftover from flatlist-grid.ejs