### PR TITLE
Fix VirtualizedList warnings expecting a String key instead of a number

### DIFF
--- a/templates/flatlist-grid.ejs
+++ b/templates/flatlist-grid.ejs
@@ -65,7 +65,7 @@ class <%= props.name %> extends React.PureComponent {
   // The default function if no Key is provided is index
   // an identifiable key is important if you plan on
   // item reordering.  Otherwise index is fine
-  keyExtractor = (item, index) => index
+  keyExtractor = (item, index) => `${index}`
 
   // How many items should be kept im memory as we scroll?
   oneScreensWorth = 20

--- a/templates/flatlist-sections.ejs
+++ b/templates/flatlist-sections.ejs
@@ -113,7 +113,7 @@ class <%= props.name %> extends React.PureComponent {
   // The default function if no Key is provided is index
   // an identifiable key is important if you plan on
   // item reordering.  Otherwise index is fine
-  keyExtractor = (item, index) => index
+  keyExtractor = (item, index) => `${index}`
 
   // How many items should be kept im memory as we scroll?
   oneScreensWorth = 20

--- a/templates/flatlist.ejs
+++ b/templates/flatlist.ejs
@@ -65,7 +65,7 @@ class <%= props.name %> extends React.PureComponent {
   // The default function if no Key is provided is index
   // an identifiable key is important if you plan on
   // item reordering.  Otherwise index is fine
-  keyExtractor = (item, index) => index
+  keyExtractor = (item, index) => `${index}`
 
   // How many items should be kept im memory as we scroll?
   oneScreensWorth = 20


### PR DESCRIPTION
FlatLists generated with Ignite would display this warning:

```
Warning: Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string`.
    in CellRenderer (at VirtualizedList.js:681)
    in RCTScrollContentView (at ScrollView.js:726)
    in RCTScrollView (at ScrollView.js:820)
    in ScrollView (at VirtualizedList.js:1009)
    in VirtualizedList (at FlatList.js:640)
``

As the [RN docs](https://facebook.github.io/react-native/docs/virtualizedlist.html#keyextractor) states, the `keyExtractor` function should return a string, not a number. 

This PR fixes that 🤗