### PR TITLE
Add ADB screencap script

### DIFF
--- a/boilerplate/package.json.ejs
+++ b/boilerplate/package.json.ejs
@@ -12,6 +12,7 @@
     "android:hockeyapp": "cd android && ./gradlew assembleRelease && puck -submit=auto app/build/outputs/apk/app-release.apk",
     "android:devices": "$ANDROID_HOME/platform-tools/adb devices",
     "android:logcat": "$ANDROID_HOME/platform-tools/adb logcat *:S ReactNative:V ReactNativeJS:V",
+    "android:screencap": "$ANDROID_HOME/platform-tools/adb shell screencap -p | perl -pe 's/\\x0D\\x0A/\\x0A/g' > screenshot.png",
     "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82",
     "storybook": "storybook start -p 7007"
     <% /* Commented out to disable tests until Enzyme becomes compatible with newer React Native versions:


### PR DESCRIPTION
# Why?
Take and save a screenshot of a device connected to your computer via ADB.

# The command as documented [here.](https://blog.shvetsov.com/2013/02/grab-android-screenshot-to-computer-via.html)

```bash
adb shell screencap -p | perl -pe 's/\x0D\x0A/\x0A/g' > screenshot.png
```

Should work on Ubuntu and macOS. I'd add `&& open screenshot.png` to the end of the command to open the file with your OS's default viewer but I think that only works on macOS.